### PR TITLE
RG-T117 Chat fix

### DIFF
--- a/src/components/chat/new-conversation-sheet.tsx
+++ b/src/components/chat/new-conversation-sheet.tsx
@@ -1,4 +1,4 @@
-import { Check, Search, Users } from 'lucide-react-native';
+import { Check, Search, Truck, Users } from 'lucide-react-native';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -34,8 +34,15 @@ function recipientUserId(recipient: RecipientsResultData): string {
 }
 
 function isPersonRecipient(recipient: RecipientsResultData): boolean {
+  // Recipients with an empty Type are the server's pseudo-entries
+  // ({ Id: "0", Name: "Everyone" } / { Id: "-1", Name: "Nobody" }) — never DM targets.
   const type = (recipient.Type ?? '').toLowerCase();
-  return type === 'personnel' || type === 'person' || type === 'user' || type === 'p' || type === '';
+  return type === 'personnel' || type === 'person' || type === 'user' || type === 'p';
+}
+
+function isUnitRecipient(recipient: RecipientsResultData): boolean {
+  const type = (recipient.Type ?? '').toLowerCase();
+  return type === 'unit' || type === 'units' || type === 'u';
 }
 
 export function NewConversationSheet({ isOpen, onClose, mode, onCreated }: NewConversationSheetProps) {
@@ -56,10 +63,13 @@ export function NewConversationSheet({ isOpen, onClose, mode, onCreated }: NewCo
     setQuery('');
     setLoadError(false);
     setLoading(true);
-    getRecipients(true, false)
+    // DM mode also offers units (Dispatch can open a 1:1 with a unit);
+    // group membership only supports users, so group mode stays people-only.
+    const includeUnits = mode === 'dm';
+    getRecipients(true, includeUnits)
       .then((result) => {
         if (cancelled) return;
-        setRecipients((result.Data ?? []).filter(isPersonRecipient));
+        setRecipients((result.Data ?? []).filter((r) => isPersonRecipient(r) || (includeUnits && isUnitRecipient(r))));
       })
       .catch((error) => {
         if (cancelled) return;
@@ -73,7 +83,7 @@ export function NewConversationSheet({ isOpen, onClose, mode, onCreated }: NewCo
     return () => {
       cancelled = true;
     };
-  }, [isOpen]);
+  }, [isOpen, mode]);
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -94,7 +104,8 @@ export function NewConversationSheet({ isOpen, onClose, mode, onCreated }: NewCo
     async (recipient: RecipientsResultData) => {
       setSubmitting(true);
       try {
-        const response = await createDirectMessage({ TargetUserId: recipientUserId(recipient) });
+        const targetId = recipientUserId(recipient);
+        const response = await createDirectMessage(isUnitRecipient(recipient) ? { TargetUnitId: parseInt(targetId, 10) } : { TargetUserId: targetId });
         if (response.Data?.ChatChannelId) {
           onCreated(response.Data.ChatChannelId);
           onClose();
@@ -110,9 +121,10 @@ export function NewConversationSheet({ isOpen, onClose, mode, onCreated }: NewCo
   );
 
   const createGroup = useCallback(async () => {
-    if (!groupName.trim() || selected.size === 0) return;
+    if (selected.size === 0) return;
     setSubmitting(true);
     try {
+      // Name is optional — the server auto-names the group after its members.
       const response = await createAdHocChannel({ Name: groupName.trim(), MemberUserIds: Array.from(selected) });
       if (response.Data?.ChatChannelId) {
         onCreated(response.Data.ChatChannelId);
@@ -139,7 +151,7 @@ export function NewConversationSheet({ isOpen, onClose, mode, onCreated }: NewCo
 
           {mode === 'group' ? (
             <Input>
-              <InputField placeholder={t('chat.group_name')} value={groupName} onChangeText={setGroupName} />
+              <InputField placeholder={t('chat.group_name_optional')} value={groupName} onChangeText={setGroupName} />
             </Input>
           ) : null}
 
@@ -167,16 +179,28 @@ export function NewConversationSheet({ isOpen, onClose, mode, onCreated }: NewCo
               {filtered.map((recipient) => {
                 const userId = recipientUserId(recipient);
                 const isSelected = selected.has(userId);
+                const isUnit = isUnitRecipient(recipient);
                 return (
                   <Pressable key={recipient.Id} className="py-2" onPress={() => (mode === 'dm' ? startDirectMessage(recipient) : toggle(userId))} disabled={submitting}>
                     <HStack className="items-center justify-between">
                       <HStack className="flex-1 items-center" space="sm">
-                        <Avatar size="sm">
-                          <AvatarImage source={{ uri: getAvatarUrl(userId) }} />
-                        </Avatar>
+                        {isUnit ? (
+                          <Center className="size-8 rounded-full bg-secondary-200">
+                            <Truck size={16} color="#6b7280" />
+                          </Center>
+                        ) : (
+                          <Avatar size="sm">
+                            <AvatarImage source={{ uri: getAvatarUrl(userId) }} />
+                          </Avatar>
+                        )}
                         <Text className="flex-1 text-typography-900" numberOfLines={1}>
                           {recipient.Name}
                         </Text>
+                        {isUnit ? (
+                          <Box className="rounded-full bg-secondary-200 px-2 py-0.5">
+                            <Text className="text-xs text-typography-600">{t('chat.unit')}</Text>
+                          </Box>
+                        ) : null}
                       </HStack>
                       {mode === 'group' && isSelected ? (
                         <Box className="rounded-full bg-primary-600 p-1">
@@ -191,7 +215,7 @@ export function NewConversationSheet({ isOpen, onClose, mode, onCreated }: NewCo
           )}
 
           {mode === 'group' ? (
-            <Button className="mb-2 w-full bg-primary-600" onPress={createGroup} isDisabled={submitting || !groupName.trim() || selected.size === 0}>
+            <Button className="mb-2 w-full bg-primary-600" onPress={createGroup} isDisabled={submitting || selected.size === 0}>
               <Users size={18} color="#ffffff" />
               <ButtonText className="ml-2">{t('chat.create_group_with', { count: selected.size })}</ButtonText>
             </Button>

--- a/src/stores/chat/__tests__/hub-invoke-args.test.ts
+++ b/src/stores/chat/__tests__/hub-invoke-args.test.ts
@@ -120,6 +120,55 @@ describe('chat hub invocations', () => {
   });
 });
 
+describe('active-channel marker resynchronization', () => {
+  // syncActiveChannelMarker settles on the microtask queue; two ticks drain it.
+  const flush = async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  };
+
+  beforeEach(async () => {
+    mockInvoke.mockClear();
+    mockInvoke.mockResolvedValue(undefined);
+    useChatStore.getState().reset();
+    await flush();
+    mockInvoke.mockClear();
+  });
+
+  it('re-asserts a non-null marker on reconnect', async () => {
+    useChatStore.getState().setActiveChannel('channel-1');
+    await flush();
+    mockInvoke.mockClear();
+
+    useChatStore.getState().handleChatConnected();
+
+    expect(mockInvoke).toHaveBeenCalledWith('chatHub', 'SetActiveChannel', 'channel-1', null);
+  });
+
+  it('retries a null marker that failed to send once reconnected', async () => {
+    mockInvoke.mockRejectedValue(new Error('disconnected'));
+    useChatStore.getState().setActiveChannel(null);
+    await flush();
+    mockInvoke.mockClear();
+    mockInvoke.mockResolvedValue(undefined);
+
+    useChatStore.getState().handleChatConnected();
+
+    expect(mockInvoke).toHaveBeenCalledWith('chatHub', 'SetActiveChannel', null, null);
+  });
+
+  it('does not resend a null marker the hub already confirmed', async () => {
+    useChatStore.getState().setActiveChannel(null);
+    await flush();
+    mockInvoke.mockClear();
+
+    useChatStore.getState().handleChatConnected();
+    await flush();
+
+    expect(mockInvoke).not.toHaveBeenCalledWith('chatHub', 'SetActiveChannel', expect.anything(), expect.anything());
+  });
+});
+
 describe('incoming message normalization', () => {
   beforeEach(() => {
     useChatStore.setState({ messagesByChannel: {}, channels: [] });

--- a/src/stores/chat/__tests__/hub-invoke-args.test.ts
+++ b/src/stores/chat/__tests__/hub-invoke-args.test.ts
@@ -8,6 +8,7 @@
  *   JoinChannel(string channelId, int? asUnitId)
  *   Typing(string channelId, string displayName, bool isTyping, int? asUnitId)
  *   MarkRead(string channelId, long seq, int? asUnitId)
+ *   SetActiveChannel(string channelId, int? asUnitId)
  */
 const mockInvoke = jest.fn().mockResolvedValue(undefined);
 
@@ -69,6 +70,15 @@ describe('chat hub invocations', () => {
     await useChatStore.getState().joinChannel('channel-1');
 
     expect(mockInvoke).toHaveBeenCalledWith('chatHub', 'JoinChannel', 'channel-1', null);
+  });
+
+  it('sends both SetActiveChannel arguments, with null clearing the marker', () => {
+    useChatStore.getState().setActiveChannel('channel-1');
+    expect(mockInvoke).toHaveBeenCalledWith('chatHub', 'SetActiveChannel', 'channel-1', null);
+
+    mockInvoke.mockClear();
+    useChatStore.getState().setActiveChannel(null);
+    expect(mockInvoke).toHaveBeenCalledWith('chatHub', 'SetActiveChannel', null, null);
   });
 
   it('sends all four Typing arguments in hub order', () => {

--- a/src/stores/chat/store.ts
+++ b/src/stores/chat/store.ts
@@ -233,6 +233,23 @@ async function safeInvoke(method: string, ...args: unknown[]): Promise<void> {
   }
 }
 
+/** Active-channel marker the hub has not confirmed yet. Kept — null included, since
+ * null means "clear the marker" — until an invoke succeeds, so a send that failed
+ * while offline can be replayed on reconnect. */
+let pendingActiveChannelSync: { channelId: string | null } | null = null;
+
+async function syncActiveChannelMarker(channelId: string | null): Promise<void> {
+  const marker = { channelId };
+  pendingActiveChannelSync = marker;
+  try {
+    await signalRService.invoke(Env.CHAT_HUB_NAME, 'SetActiveChannel', channelId, null);
+    // Only clear if no newer marker superseded this one while in flight.
+    if (pendingActiveChannelSync === marker) pendingActiveChannelSync = null;
+  } catch (error) {
+    logger.debug({ message: 'chat: invoke SetActiveChannel skipped', context: { error } });
+  }
+}
+
 export const useChatStore = create<ChatState>()(
   persist(
     (set, get) => ({
@@ -287,7 +304,7 @@ export const useChatStore = create<ChatState>()(
         set({ activeChannelId: channelId });
         // Report the actively viewed conversation to the hub so the server can
         // suppress push notifications for it; null clears the marker.
-        void safeInvoke('SetActiveChannel', channelId ?? null, null);
+        void syncActiveChannelMarker(channelId ?? null);
       },
 
       // ------------------------------------------------------------------
@@ -853,9 +870,13 @@ export const useChatStore = create<ChatState>()(
         if (activeChannelId) {
           void get().joinChannel(activeChannelId);
           void get().loadNewerMessages(activeChannelId);
-          // Re-report the active conversation so the server-side notification
-          // suppression marker survives reconnects.
-          void safeInvoke('SetActiveChannel', activeChannelId, null);
+        }
+        // Re-report the active conversation so the server-side notification
+        // suppression marker survives reconnects. A pending null (screen closed
+        // while offline) is flushed too, so the server stops suppressing push
+        // for a channel no longer on screen.
+        if (activeChannelId !== null || pendingActiveChannelSync !== null) {
+          void syncActiveChannelMarker(activeChannelId);
         }
       },
 
@@ -865,6 +886,7 @@ export const useChatStore = create<ChatState>()(
         lastTypingSentAt.clear();
         lastMarkedSeq.clear();
         pendingChatbotMessages.clear();
+        pendingActiveChannelSync = null;
         clearChatbotTypingTimeout();
         if (outboxDrainTimer) {
           clearTimeout(outboxDrainTimer);

--- a/src/stores/chat/store.ts
+++ b/src/stores/chat/store.ts
@@ -285,6 +285,9 @@ export const useChatStore = create<ChatState>()(
 
       setActiveChannel: (channelId: string | null) => {
         set({ activeChannelId: channelId });
+        // Report the actively viewed conversation to the hub so the server can
+        // suppress push notifications for it; null clears the marker.
+        void safeInvoke('SetActiveChannel', channelId ?? null, null);
       },
 
       // ------------------------------------------------------------------
@@ -850,6 +853,9 @@ export const useChatStore = create<ChatState>()(
         if (activeChannelId) {
           void get().joinChannel(activeChannelId);
           void get().loadNewerMessages(activeChannelId);
+          // Re-report the active conversation so the server-side notification
+          // suppression marker survives reconnects.
+          void safeInvoke('SetActiveChannel', activeChannelId, null);
         }
       },
 

--- a/src/translations/ar.json
+++ b/src/translations/ar.json
@@ -384,6 +384,8 @@
     "open_assistant": "فتح المساعد",
     "create_conversation_failed": "تعذّر بدء المحادثة",
     "group_name": "اسم المجموعة",
+    "group_name_optional": "اسم المجموعة (اختياري)",
+    "unit": "الوحدة",
     "search_people": "البحث عن أشخاص",
     "no_people": "لم يتم العثور على أشخاص",
     "create_group_with": "إنشاء مجموعة ({{count}})",

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -384,6 +384,8 @@
     "open_assistant": "Assistent öffnen",
     "create_conversation_failed": "Unterhaltung konnte nicht gestartet werden",
     "group_name": "Gruppenname",
+    "group_name_optional": "Gruppenname (optional)",
+    "unit": "Einheit",
     "search_people": "Personen suchen",
     "no_people": "Keine Personen gefunden",
     "create_group_with": "Gruppe erstellen ({{count}})",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -384,6 +384,8 @@
     "open_assistant": "Open Assistant",
     "create_conversation_failed": "Could not start the conversation",
     "group_name": "Group name",
+    "group_name_optional": "Group name (optional)",
+    "unit": "Unit",
     "search_people": "Search people",
     "no_people": "No people found",
     "create_group_with": "Create group ({{count}})",

--- a/src/translations/es.json
+++ b/src/translations/es.json
@@ -384,6 +384,8 @@
     "open_assistant": "Abrir asistente",
     "create_conversation_failed": "No se pudo iniciar la conversación",
     "group_name": "Nombre del grupo",
+    "group_name_optional": "Nombre del grupo (opcional)",
+    "unit": "Unidad",
     "search_people": "Buscar personas",
     "no_people": "No se encontraron personas",
     "create_group_with": "Crear grupo ({{count}})",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -384,6 +384,8 @@
     "open_assistant": "Ouvrir l'assistant",
     "create_conversation_failed": "Impossible de démarrer la conversation",
     "group_name": "Nom du groupe",
+    "group_name_optional": "Nom du groupe (facultatif)",
+    "unit": "Unité",
     "search_people": "Rechercher des personnes",
     "no_people": "Aucune personne trouvée",
     "create_group_with": "Créer un groupe ({{count}})",

--- a/src/translations/it.json
+++ b/src/translations/it.json
@@ -384,6 +384,8 @@
     "open_assistant": "Apri assistente",
     "create_conversation_failed": "Impossibile avviare la conversazione",
     "group_name": "Nome del gruppo",
+    "group_name_optional": "Nome del gruppo (facoltativo)",
+    "unit": "Unità",
     "search_people": "Cerca persone",
     "no_people": "Nessuna persona trovata",
     "create_group_with": "Crea gruppo ({{count}})",

--- a/src/translations/pl.json
+++ b/src/translations/pl.json
@@ -384,6 +384,8 @@
     "open_assistant": "Otwórz asystenta",
     "create_conversation_failed": "Nie można rozpocząć rozmowy",
     "group_name": "Nazwa grupy",
+    "group_name_optional": "Nazwa grupy (opcjonalnie)",
+    "unit": "Jednostka",
     "search_people": "Szukaj osób",
     "no_people": "Nie znaleziono osób",
     "create_group_with": "Utwórz grupę ({{count}})",

--- a/src/translations/sv.json
+++ b/src/translations/sv.json
@@ -384,6 +384,8 @@
     "open_assistant": "Öppna assistent",
     "create_conversation_failed": "Det gick inte att starta konversationen",
     "group_name": "Gruppnamn",
+    "group_name_optional": "Gruppnamn (valfritt)",
+    "unit": "Enhet",
     "search_people": "Sök personer",
     "no_people": "Inga personer hittades",
     "create_group_with": "Skapa grupp ({{count}})",

--- a/src/translations/uk.json
+++ b/src/translations/uk.json
@@ -384,6 +384,8 @@
     "open_assistant": "Відкрити асистента",
     "create_conversation_failed": "Не вдалося розпочати розмову",
     "group_name": "Назва групи",
+    "group_name_optional": "Назва групи (необов'язково)",
+    "unit": "Підрозділ",
     "search_people": "Пошук людей",
     "no_people": "Людей не знайдено",
     "create_group_with": "Створити групу ({{count}})",


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Pull Request Description

**RG-T117 Chat fix**

This PR introduces several improvements to the chat functionality:

### New Features & Enhancements

1. **Direct messages with units**: Users can now start 1:1 conversations with units (not just personnel). When starting a DM with a unit, the request is sent with `TargetUnitId` instead of `TargetUserId`. Units are visually distinguished with a truck icon and a "Unit" badge instead of a user avatar.

2. **Optional group name**: Group chat creation no longer requires a name. The server auto-names groups based on their members. The placeholder text and validation were updated accordingly.

3. **Active channel notification suppression**: The app now reports the currently viewed conversation to the chat hub via a new `SetActiveChannel` invocation, allowing the server to suppress push notifications for the conversation the user is actively viewing. This state is also re-established automatically after connection drops/reconnects.

### Bug Fixes

- **Excluded pseudo-entries from recipients**: Server pseudo-entries (e.g., "Everyone" with empty Type) are no longer incorrectly treated as valid direct message targets.
- **Recipient reload on mode change**: Added `mode` to the effect dependency array so recipients are properly refreshed when switching between DM and group modes.
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Direct-message conversations can now target units, displayed with dedicated icons and labels.
  * Group conversations can be created without entering a name.
  * Recipient lists refresh automatically when the conversation type changes.
  * Added localized labels for units and optional group names across supported languages.

* **Bug Fixes**
  * Improved active-channel synchronization after reconnecting, including reliable clearing and retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->