### PR TITLE
RD-T43 Style fix

### DIFF
--- a/src/components/ui/icon/index.tsx
+++ b/src/components/ui/icon/index.tsx
@@ -31,12 +31,15 @@ const iconStyle = tva({
 const StyledUIIcon = styled(UIIcon, {
   className: {
     target: 'style',
+    // Values must be prop paths, never `true`: react-native-css resolves each one with
+    // `path.split('.')`, so a boolean throws "undefined is not a function" the moment the class
+    // actually produces that style key — which for the size variants is every render.
     nativeStyleMapping: {
-      height: true,
-      width: true,
-      fill: true,
+      height: 'height',
+      width: 'width',
+      fill: 'fill',
       color: 'classNameColor',
-      stroke: true,
+      stroke: 'stroke',
     },
   },
 });

--- a/src/components/ui/spinner/index.tsx
+++ b/src/components/ui/spinner/index.tsx
@@ -5,7 +5,9 @@ import React from 'react';
 import { ActivityIndicator } from 'react-native';
 
 const StyledActivityIndicator = styled(ActivityIndicator, {
-  className: { target: 'style', nativeStyleMapping: { color: true } },
+  // A prop path, not `true`: react-native-css calls `.split('.')` on the value, so a boolean
+  // crashes as soon as the className resolves to a colour.
+  className: { target: 'style', nativeStyleMapping: { color: 'color' } },
 });
 
 const spinnerStyle = tva({});


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary
Fixes style mapping issues in shared UI components so class-based styling no longer crashes when applying icon sizing/colors or spinner colors.

## What changed
- Updated the `Icon` component’s native style mapping to use explicit prop paths for:
  - `height`
  - `width`
  - `fill`
  - `stroke`
- Updated the `Spinner` component’s native style mapping to use an explicit prop path for:
  - `color`

## Functional impact
- Prevents runtime errors caused when class-based styles are resolved for these components.
- Restores reliable styling behavior for icons and spinners, especially when applying size and color-related classes.
- Ensures these UI components can safely consume style values from `className` mappings in React Native.
<!-- kody-pr-summary:end -->